### PR TITLE
Fix tomcat deployed to `${server.home.dir}/webapps/` bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vscode/.vscode-test/
 vscode/coverage
 .project
 .settings/
+.idea/

--- a/rsp/runtimes/bundles/org.jboss.tools.rsp.server.tomcat/src/main/resources/servers.json
+++ b/rsp/runtimes/bundles/org.jboss.tools.rsp.server.tomcat/src/main/resources/servers.json
@@ -260,7 +260,7 @@
 						},
 						"server.deploy.dir": {
 							"type": "string",
-							"value": "webapps/"
+							"value": "${server.base.dir}/webapps/"
 						}
 					}
 				},


### PR DESCRIPTION
Change ${se…rver.deploy.dir} from relative path `webapps/` to absolute path `${server.base.dir}/webapps/`