### PR TITLE
Fixes #152 checkJavaRuntime reject model

### DIFF
--- a/vscode/src/requirements.ts
+++ b/vscode/src/requirements.ts
@@ -123,6 +123,7 @@ function rejectWithDownloadUrl(reject: {
         label: string;
         openUrl: Uri;
         replaceClose: boolean;
+        btns: { label: string; openUrl: Uri; }[];
     }): void;
 }, message: string): void {
     let jdkUrl = newLocal;
@@ -133,6 +134,12 @@ function rejectWithDownloadUrl(reject: {
         message: message,
         label: 'Get the Java Development Kit',
         openUrl: Uri.parse(jdkUrl),
-        replaceClose: false
+        replaceClose: false,
+        btns: [
+            {
+                label: 'Get the Java Development Kit',
+                openUrl: Uri.parse(jdkUrl),
+            }
+        ]
     });
 }


### PR DESCRIPTION
If JDK is not set, the `showErrorMessage` pop-up window does not occur.

It occurs because there is no btns value in error in server.ts,
Modified model of `rejectWithDownloadUrl` in requirements.ts.

Changed the popup to appear as below.  
<img src="https://user-images.githubusercontent.com/25363091/210217517-d59740d7-e279-48ee-9165-cec2b6a95935.png" width=50% height=50%>  

It seems to be related to the issue below.
#134