### PR TITLE
Fix macOS GitHub Actions build failures

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,17 +22,18 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Java ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
-        java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
-        architecture: x64
     - name: Setup node ${{ matrix.node }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node }}
     - name: Build RSP part using Maven
       working-directory: rsp
+      env:
+        MAVEN_OPTS: -Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.entityExpansionLimit=0
       run: mvn clean install -U -fae -e -B
     - name: Cache Version
       working-directory: vscode


### PR DESCRIPTION
Fixes #247

## Summary
- Upgrade setup-java action from v1 to v4 for ARM64 macOS support
- Add MAVEN_OPTS to fix JAXP XML entity size limit errors

## Problem
macOS builds were failing with two errors:
1. `JAVA_HOME environment variable is not defined correctly` - caused by setup-java v1 not supporting ARM64 macOS runners (macos-latest now uses Apple Silicon)
2. `JAXP00010004: The accumulated size of entities exceeded the limit` - caused by strict XML parsing limits when loading p2 repositories

## Solution

### 1. Upgrade setup-java action
- Changed from `actions/setup-java@v1` to `actions/setup-java@v4`
- Use Temurin distribution (supports both x64 and ARM64)
- Remove hardcoded `architecture: x64` to allow auto-detection
- v4 properly handles ARM64 macOS runners

### 2. Add MAVEN_OPTS environment variable
- Set `MAVEN_OPTS` with XML parsing limits disabled:
  - `-Djdk.xml.maxGeneralEntitySizeLimit=0`
  - `-Djdk.xml.totalEntitySizeLimit=0`
  - `-Djdk.xml.entityExpansionLimit=0`
- Allows Maven/Tycho to parse large p2 repository metadata files

## Test plan
- CI build on macOS should now succeed
- Existing Linux and Windows builds remain unaffected
- Verify Maven can load p2 repositories without JAXP errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)