### PR TITLE
Fix flaky extension installed UI test

### DIFF
--- a/vscode/test/ui-test/extensionInstalledUITest.ts
+++ b/vscode/test/ui-test/extensionInstalledUITest.ts
@@ -21,9 +21,32 @@ export function extensionInstalledUITest(): void {
 
     it('RSP server community extension is installed', async function () {
       this.timeout(20000);
-      const item = (await section.findItem(`@installed ` + AdaptersConstants.RSP_EXTENSTION_NAME)) as ExtensionsViewItem;
-      expect(item).not.undefined;
-      expect(await item.getTitle()).to.equal(AdaptersConstants.RSP_EXTENSTION_NAME);
+
+      // Retry logic to handle StaleElementReferenceError
+      const maxRetries = 3;
+      let lastError: Error | undefined;
+
+      for (let attempt = 0; attempt < maxRetries; attempt++) {
+        try {
+          const item = (await section.findItem(`@installed ` + AdaptersConstants.RSP_EXTENSTION_NAME)) as ExtensionsViewItem;
+          expect(item).not.undefined;
+          const title = await item.getTitle();
+          expect(title).to.equal(AdaptersConstants.RSP_EXTENSTION_NAME);
+          return; // Success, exit the test
+        } catch (error: any) {
+          lastError = error;
+          if (error.name === 'StaleElementReferenceError' && attempt < maxRetries - 1) {
+            // Wait a bit before retrying
+            await new Promise(resolve => setTimeout(resolve, 500));
+            continue;
+          }
+          // If it's not a stale element error, or we're out of retries, throw
+          throw error;
+        }
+      }
+
+      // If we get here, all retries failed
+      throw lastError!;
     });
 
     afterEach(async function () {


### PR DESCRIPTION
Fixes #249

## Summary
- Add retry logic to handle StaleElementReferenceError in extension UI test
- Eliminates ~50% failure rate on Ubuntu CI builds

## Problem
The extension installed UI test was flaky, failing approximately 50% of the time with:
```
StaleElementReferenceError: stale element reference: stale element not found in the current frame
  at async ExtensionsViewItem.getTitle()
  at async ExtensionsViewSection.findItem()
```

**Root cause:** Between finding the extension item and calling `getTitle()`, VS Code refreshes the extensions list DOM, making the element reference stale.

## Solution
Added retry logic that:
- Wraps the find + getTitle operations in a try/catch retry loop
- Catches `StaleElementReferenceError` specifically
- Retries up to 3 times with 500ms delay between attempts
- Re-throws other errors immediately
- Re-throws on final retry if still failing

This handles the timing issue without making the test less strict - it still validates the extension is installed and has the correct name.

## Test plan
- Run the UI tests multiple times to verify they no longer fail intermittently
- CI should now have consistently green builds on Ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)